### PR TITLE
Channel all input events through _forward_3d_gui_input instead of _input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ https://github.com/bikemurt/godot-vertex-painter/assets/23486102/fea58b3f-8b71-4
 
 ## ⚠️ Limitations
 
-- Only imported meshes will work (or ArrayMesh, which have a clear_surfaces() method)
-
 ## 🏠 Links
 
 - [Homepage](https://www.michaeljared.ca/)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ https://github.com/bikemurt/godot-vertex-painter/assets/23486102/fea58b3f-8b71-4
 ## ⚠️ Limitations
 
 - Only imported meshes will work (or ArrayMesh, which have a clear_surfaces() method)
-- Scale *must* be applied to meshes prior to trying to vertex paint them
 
 ## 🏠 Links
 

--- a/addons/vertex_painter/v2/vertex_painter.gd
+++ b/addons/vertex_painter/v2/vertex_painter.gd
@@ -16,7 +16,36 @@ func set_screen_name(_screen: String) -> void:
 func _ready():
 	vertex_painter_3d.set_interface(editor_interface)
 
+func _enter_tree() -> void:
+	EditorInterface.get_selection().selection_changed.connect(_selection_changed)
+
+func _exit_tree() -> void:
+	EditorInterface.get_selection().selection_changed.disconnect(_selection_changed)
+
+func _selection_changed() -> void:
+	vertex_painter_3d.disable()
+	enable_check_box.button_pressed = false
+
 func _on_enable_check_box_pressed():
+	var target = find_target()
+	
 	if enable_check_box.button_pressed:
+		if !is_instance_valid(target):
+			enable_check_box.button_pressed = false
+			vertex_painter_3d.err("You must select a MeshInstance3D to vertex paint.")
+			return
 		editor_interface.set_main_screen_editor("Script")
 		editor_interface.set_main_screen_editor("3D")
+		vertex_painter_3d.enable(target)
+	else:
+		vertex_painter_3d.disable()
+
+func find_target() -> MeshInstance3D:
+	var nodes := editor_interface.get_selection().get_selected_nodes()
+	for n in nodes:
+		if n is MeshInstance3D:
+			return n
+	return null
+
+func is_enabled() -> bool:
+	return enable_check_box.button_pressed

--- a/addons/vertex_painter/v2/vertex_painter.tscn
+++ b/addons/vertex_painter/v2/vertex_painter.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://bnfl4nwux8mc4"]
+[gd_scene load_steps=10 format=3 uid="uid://bnfl4nwux8mc4"]
 
-[ext_resource type="Script" path="res://addons/vertex_painter/v2/vertex_painter.gd" id="1_pituq"]
-[ext_resource type="Script" path="res://addons/vertex_painter/v2/vertex_painter_3d.gd" id="2_vflpc"]
-[ext_resource type="Shader" path="res://addons/vertex_painter/v2/gpu_depth.gdshader" id="3_8jrka"]
+[ext_resource type="Script" uid="uid://bg4ok23dxt2dj" path="res://addons/vertex_painter/v2/vertex_painter.gd" id="1_pituq"]
+[ext_resource type="Script" uid="uid://dyqepfgs1pmsh" path="res://addons/vertex_painter/v2/vertex_painter_3d.gd" id="2_vflpc"]
+[ext_resource type="Shader" uid="uid://cc7043s41qu1h" path="res://addons/vertex_painter/v2/gpu_depth.gdshader" id="3_8jrka"]
 
 [sub_resource type="Environment" id="Environment_hpdng"]
 
@@ -12,12 +12,15 @@ size = Vector2(0.1, 0.1)
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_yrme8"]
 render_priority = 0
 shader = ExtResource("3_8jrka")
-shader_parameter/camera_far = 100000.0
+shader_parameter/camera_far = 10000.0
 
 [sub_resource type="SphereMesh" id="SphereMesh_8olv6"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_eghqw"]
 albedo_color = Color(0.933333, 1, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_q845s"]
+albedo_color = Color(0.26676348, 0.4145387, 1, 1)
 
 [node name="VertexPainter" type="CenterContainer"]
 anchors_preset = 15
@@ -80,7 +83,7 @@ cull_mask = 1
 environment = SubResource("Environment_hpdng")
 projection = 1
 size = 0.1
-far = 100000.0
+far = 10000.0
 
 [node name="ScreenQuad" type="MeshInstance3D" parent="SubViewport/MouseCamera3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.5)
@@ -88,10 +91,18 @@ mesh = SubResource("QuadMesh_4magw")
 surface_material_override/0 = SubResource("ShaderMaterial_yrme8")
 
 [node name="Debug" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0)
 visible = false
 layers = 2
 mesh = SubResource("SphereMesh_8olv6")
 surface_material_override/0 = SubResource("StandardMaterial3D_eghqw")
+
+[node name="DebugVertex" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0)
+visible = false
+layers = 2
+mesh = SubResource("SphereMesh_8olv6")
+surface_material_override/0 = SubResource("StandardMaterial3D_q845s")
 
 [connection signal="pressed" from="VBoxContainer/EnableCheckBox" to="." method="_on_enable_check_box_pressed"]
 [connection signal="focus_exited" from="VBoxContainer/BrushLineEdit" to="VertexPainter3D" method="_on_brush_line_edit_focus_exited"]

--- a/addons/vertex_painter/v2/vertex_painter_3d.gd
+++ b/addons/vertex_painter/v2/vertex_painter_3d.gd
@@ -156,7 +156,7 @@ func process_click(event: InputEvent) -> void:
 func paint() -> void:
 		var result2 = click_raycast2()
 		if result2.is_finite():
-			var vertices := get_n_closest_vertices(active_mdt, mesh_i.global_position, \
+			var vertices := get_n_closest_vertices(active_mdt, mesh_i.global_transform, \
 				result2, brush_size)
 			for idx in vertices:
 				active_mdt.set_vertex_color(idx, color_picker.color)
@@ -166,7 +166,7 @@ func paint() -> void:
 func legacy_paint() -> void:
 	var result = click_raycast()
 	if "position" in result:
-		var vertices := get_n_closest_vertices(active_mdt, mesh_i.global_position, \
+		var vertices := get_n_closest_vertices(active_mdt, mesh_i.global_transform, \
 			result.position, brush_size)
 		for idx in vertices:
 			active_mdt.set_vertex_color(idx, color_picker.color)
@@ -185,12 +185,12 @@ func process_move(event: InputEvent) -> void:
 		await get_tree().create_timer(0.05).timeout
 		working = false
 	
-func get_n_closest_vertices(mdt: MeshDataTool, mesh_pos: Vector3, \
+func get_n_closest_vertices(mdt: MeshDataTool, mesh_transform: Transform3D, \
 	hit_pos: Vector3, n: int) -> Array[int]:
 	
 	var vertices := []
 	for v in range(mdt.get_vertex_count()):
-		var v_pos := mdt.get_vertex(v) + mesh_pos
+		var v_pos := mesh_transform * mdt.get_vertex(v)
 		var dist := hit_pos.distance_squared_to(v_pos)
 		
 		if len(vertices) < n:

--- a/addons/vertex_painter/vertex_painter.gd
+++ b/addons/vertex_painter/vertex_painter.gd
@@ -13,8 +13,16 @@ func _enter_tree():
 	main_screen_changed.connect(main_panel_instance.set_screen_name)
 	
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_UR, main_panel_instance)
-	
-	
+
 func _exit_tree():
 	remove_control_from_docks(main_panel_instance)
 	main_panel_instance.free()
+
+func _forward_3d_gui_input(cam: Camera3D, event: InputEvent) -> int:
+	if main_panel_instance.is_enabled():
+		return main_panel_instance.vertex_painter_3d._forward_3d_gui_input(cam, event)
+	else:
+		return EditorPlugin.AFTER_GUI_INPUT_PASS
+
+func _handles(object: Object) -> bool:
+	return object is MeshInstance3D


### PR DESCRIPTION
This reduces jank in the editor. For example, dragging with the mouse in the 3d viewport will no longer show the selection rectangle. A side effect is that the user now needs to select the mesh instance first before being able to enable vertex paint.

Also non-ArrayMeshes will now be automatically converted to ArrayMesh using SurfaceTool.

Tested in Godot 4.5.stable